### PR TITLE
Add a simple clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It will build a `butterfly-assembly-{version}.jar` somewhere in `target/` contai
 
 And that's all !
 
-### With Maven (not recommended)
+### With Maven
 
 To build
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ And that's all !
 
 To build
 
-`mvn clean package`
+`mvn clean package -U`
 
 It will build a `.jar` inside the `target/` directory
 

--- a/src/main/scala/io/atal/butterfly/Clipboard.scala
+++ b/src/main/scala/io/atal/butterfly/Clipboard.scala
@@ -7,10 +7,10 @@ package io.atal.butterfly
 class Clipboard {
   var _data: String = ""
 
-  def data = _data
-  def data_=(data: String) = _data = data
+  def data: String = _data
+  def data_=(data: String): Unit = _data = data
 
   /** Clear the data with an empty String
     */
-  def clearData = _data = ""
+  def clearData: Unit = _data = ""
 }

--- a/src/main/scala/io/atal/butterfly/Clipboard.scala
+++ b/src/main/scala/io/atal/butterfly/Clipboard.scala
@@ -1,0 +1,16 @@
+package io.atal.butterfly
+
+/** The Clipboard keeps a single text data
+  *
+  * @constructor Create a new Clipboard with empty data
+  */
+class Clipboard {
+  var _data: String = ""
+
+  def data = _data
+  def data_=(data: String) = _data = data
+
+  /** Clear the data with an empty String
+    */
+  def clearData = _data = ""
+}

--- a/src/test/scala/io/atal/butterfly/ClipboardTest.scala
+++ b/src/test/scala/io/atal/butterfly/ClipboardTest.scala
@@ -1,0 +1,29 @@
+package io.atal.butterfly
+
+import org.scalatest._
+
+/** Clipboard unit test
+  */
+class ClipboardTest extends FlatSpec {
+
+  "The Clipboard accessor and mutator" should "be as expected" in {
+    val clipboard = new Clipboard
+
+    assert(clipboard.data == "")
+
+    val expected = "#clipboard"
+    clipboard.data = expected
+
+    assert(clipboard.data == expected)
+  }
+
+  "The Clipboard clear method" should "empty the data" in {
+    val clipboard = new Clipboard
+    clipboard.data = "#dirty"
+
+    val expected = ""
+    clipboard.clearData
+
+    assert(clipboard.data == expected)
+  }
+}


### PR DESCRIPTION
A simple home-made clipboard
- put a single text data in it (on user's copy event)
- get the stored data (on user's paste event)
- clear the stored data

**Info**
ScalaDoc convention : http://docs.scala-lang.org/style/scaladoc.html
Scala style guide : http://docs.scala-lang.org/style/
