### PR TITLE
Fix & Add informations in build tools (sbt, mvn)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ name := "Butterfly"
 
 version := "0.0.1"
 
+organization := "io.atal"
+
 scalaVersion := "2.11.4"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1" % "test"

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.atal.butterfly</groupId>
+  <groupId>io.atal</groupId>
   <artifactId>butterfly</artifactId>
   <version>0.0.1</version>
   <packaging>jar</packaging>


### PR DESCRIPTION
`groupId` in `pom.xml` was bad.
`organization` was missing in `build.sbt`.
